### PR TITLE
Added release trigger type for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   release:
+    types: [released]
 
 defaults:
   run:


### PR DESCRIPTION
The release trigger can be invoked on different occasions: when created, deleted, edited, published, etc (cf. https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release). This results in the creation of multiple workflow runs:
![image](https://github.com/liris-xr/PLUME-Python/assets/20073809/44909929-21e1-45fd-9d31-c06fdb8c21dc)

The following change ensures that the release action (i.e. publishing on PyPi) is only triggered when "A release was published, or a pre-release was changed to a release." as per the documentation.